### PR TITLE
Implement a text search command

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ source 'https://rubygems.org'
 gem 'commander-openflighthpc', '~> 2'
 gem 'hashie'
 gem 'output_mode'
-gem 'pastel'
+gem 'picky'
 # NOTE: Remember to remove the patch before updating TTY::Markdown to version 0.7
 gem 'tty-markdown', '~> 0.6.0'
 gem 'tty-pager'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,30 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (6.0.3.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2, >= 2.2.2)
     byebug (11.1.3)
     coderay (1.1.3)
     commander-openflighthpc (2.2.0)
       highline (> 1.7.2)
       paint (~> 2.1.0)
       slop (~> 4.8)
+    concurrent-ruby (1.1.7)
     equatable (0.6.1)
     hashie (4.1.0)
     highline (2.0.3)
+    i18n (1.8.5)
+      concurrent-ruby (~> 1.0)
     kramdown (1.16.2)
     method_source (1.0.0)
+    minitest (5.14.2)
+    multi_json (1.15.0)
     necromancer (0.6.0)
-    output_mode (1.1.1)
+    output_mode (1.4.0)
       pastel (>= 0.7)
       tty-color (>= 0.5)
       tty-table (>= 0.11)
@@ -21,12 +32,18 @@ GEM
     pastel (0.7.4)
       equatable (~> 0.6)
       tty-color (~> 0.5)
+    picky (4.31.3)
+      activesupport
+      multi_json (~> 1.3)
+      rack_fast_escape (~> 2009.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
+    rack_fast_escape (2009.06.24)
+      url_escape
     rouge (3.22.0)
     slop (4.8.2)
     strings (0.1.8)
@@ -34,7 +51,8 @@ GEM
       unicode-display_width (~> 1.5)
       unicode_utils (~> 1.4)
     strings-ansi (0.2.0)
-    tty-color (0.5.2)
+    thread_safe (0.3.6)
+    tty-color (0.6.0)
     tty-markdown (0.6.0)
       kramdown (~> 1.16.2)
       pastel (~> 0.7.2)
@@ -52,10 +70,14 @@ GEM
       pastel (~> 0.7.2)
       strings (~> 0.1.5)
       tty-screen (~> 0.7)
+    tzinfo (1.2.8)
+      thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
     unicode_utils (1.4.0)
+    url_escape (2009.06.24)
     word_wrap (1.0.0)
     xdg (4.2.0)
+    zeitwerk (2.4.1)
 
 PLATFORMS
   ruby
@@ -64,7 +86,7 @@ DEPENDENCIES
   commander-openflighthpc (~> 2)
   hashie
   output_mode
-  pastel
+  picky
   pry
   pry-byebug
   tty-markdown (~> 0.6.0)

--- a/lib/flight-howto/cli.rb
+++ b/lib/flight-howto/cli.rb
@@ -70,6 +70,10 @@ module FlightHowto
       c.slop.bool '--no-pretty', 'Display as raw markdown', default: false
     end
 
+    create_command 'search', 'TERMS...' do |c|
+      c.summary = 'List guides which contain the given search terms'
+    end
+
     alias_command 'ls', 'list'
 
     if Config::CACHE.development?

--- a/lib/flight-howto/cli.rb
+++ b/lib/flight-howto/cli.rb
@@ -59,9 +59,11 @@ module FlightHowto
       end
     end
 
+    global_slop.bool '--verbose', 'Display additional information'
+    global_slop.bool '--ascii', 'Display the uncolorized ASCII output'
+
     create_command 'list' do |c|
       c.summary = 'List available user guides'
-      c.slop.bool '--verbose', 'Display additional information'
     end
 
     create_command 'show', 'NAME...' do |c|

--- a/lib/flight-howto/commands/list.rb
+++ b/lib/flight-howto/commands/list.rb
@@ -25,10 +25,6 @@
 # https://github.com/openflighthpc/flight-howto
 #==============================================================================
 
-require 'output_mode'
-require 'pathname'
-require 'pastel'
-
 module FlightHowto
   module Commands
     class List < Command
@@ -37,7 +33,8 @@ module FlightHowto
         if guides.empty?
           $stderr.puts 'No guides found!'
         else
-          puts Lister.build_output(verbose: options.verbose).render(*guides)
+          puts Lister.build_output(ascii: options.ascii, verbose: options.verbose)
+                     .render(*guides)
         end
       end
     end

--- a/lib/flight-howto/commands/search.rb
+++ b/lib/flight-howto/commands/search.rb
@@ -25,10 +25,6 @@
 # https://github.com/openflighthpc/flight-howto
 #==============================================================================
 
-require 'output_mode'
-require 'pathname'
-require 'pastel'
-
 module FlightHowto
   module Commands
     class Search < Command
@@ -37,7 +33,8 @@ module FlightHowto
         if guides.empty?
           $stderr.puts 'No guides found!'
         else
-          puts Lister.build_output(verbose: options.verbose).render(*guides)
+          puts Lister.build_output(ascii: options.ascii, verbose: options.verbose)
+                     .render(*guides)
         end
       end
     end

--- a/lib/flight-howto/commands/search.rb
+++ b/lib/flight-howto/commands/search.rb
@@ -1,0 +1,45 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of FlightHowto.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightHowto is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightHowto. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightHowto, please visit:
+# https://github.com/openflighthpc/flight-howto
+#==============================================================================
+
+require 'output_mode'
+require 'pathname'
+require 'pastel'
+
+module FlightHowto
+  module Commands
+    class Search < Command
+      def run
+        guides = Matcher.new.search_content(args.join(' '))
+        if guides.empty?
+          $stderr.puts 'No guides found!'
+        else
+          puts Lister.build_output(verbose: options.verbose).render(*guides)
+        end
+      end
+    end
+  end
+end

--- a/lib/flight-howto/commands/show.rb
+++ b/lib/flight-howto/commands/show.rb
@@ -63,9 +63,12 @@ module FlightHowto
           if guides.length == 1
             guides.first
           elsif guides.length > 1
+            # Always display the interactive output as the error message is
+            # inherently user facing
+            out = Lister.build_output(ascii: options.ascii, verbose: options.verbose, interactive: true)
             raise MissingError, <<~ERROR.chomp
               Could not uniquely identify a guide. Did you mean one of the following?
-              #{Paint[Lister.build_output(verbose: false).render(*guides), :reset]}
+              #{Paint[out.render(*guides), :reset]}
             ERROR
           else
             raise MissingError, "Could not locate: #{args.join(' ')}"

--- a/lib/flight-howto/commands/show.rb
+++ b/lib/flight-howto/commands/show.rb
@@ -77,7 +77,7 @@ module FlightHowto
         Guide.standardize_string(args.join('_'))
              .split('_')
              .uniq
-             .reduce(matcher) { |memo, key| memo.search(key) }
+             .reduce(matcher) { |memo, key| memo.search_name(key) }
              .guides
       end
 

--- a/lib/flight-howto/guide.rb
+++ b/lib/flight-howto/guide.rb
@@ -26,6 +26,7 @@
 #==============================================================================
 
 require 'tty-pager'
+require 'securerandom'
 
 require_relative 'renderer'
 require_relative 'parser'
@@ -64,6 +65,13 @@ module FlightHowto
         @prefix = nil
         @joined = name
       end
+    end
+
+    ##
+    # A random identifier used to back reference from the search algorithm
+    # It is not intended to be exposed to the end user
+    def id
+      @id ||= SecureRandom.uuid
     end
 
     ##

--- a/lib/flight-howto/lister.rb
+++ b/lib/flight-howto/lister.rb
@@ -39,13 +39,11 @@ module FlightHowto
     end
 
     # Define the name column (toggles on verbosity)
-    { header: 'Name', row_color: :cyan }.tap do |o|
-      register_column(verbose: true, **o) do |guide|
-        guide.parts.join('_')
-      end
-
-      register_column(verbose: false, **o) do |guide|
+    register_column(header: 'Name', row_color: :cyan) do |guide|
+      if $stdout.tty?
         guide.humanized_name
+      else
+        guide.parts.join('_')
       end
     end
 

--- a/lib/flight-howto/lister.rb
+++ b/lib/flight-howto/lister.rb
@@ -27,28 +27,35 @@
 
 require 'output_mode'
 require 'pathname'
-require 'pastel'
 
 module FlightHowto
   module Lister
     # Defines a handy interface for generating Tabulated data
     extend OutputMode::TLDR::Index
 
-    # Defines the columns to the output as a series of blocks
-    # Essentially each "callable" is a proc and a config rolled into a single object
-    register_callable(header: 'Index') do |guide|
-      # NOTE: The OutputMode library does not supprt *_with_index type notation
-      #       Instead the index needs to be cached on the object itself
-      $stdout.tty? ? pastel.yellow(guide.index) : guide.index
+    # Define the index column
+    register_column(header: 'Index', row_color: :yellow) do |guide|
+      guide.index
     end
-    register_callable(header: 'Name') do |guide|
-      if $stdout.tty?
-        pastel.cyan guide.humanized_name
-      else
+
+    # Define the name column (toggles on verbosity)
+    { header: 'Name', row_color: :cyan }.tap do |o|
+      register_column(verbose: true, **o) do |guide|
         guide.parts.join('_')
       end
+
+      register_column(verbose: false, **o) do |guide|
+        guide.humanized_name
+      end
     end
-    register_callable(header: "File (Dir: #{Config::CACHE.howto_dir})", verbose: true) do |guide|
+
+    # Define the file column (toggles on verbosity)
+    register_column(header: "File (Dir: #{Config::CACHE.howto_dir})", verbose: true) do |guide|
+      # NOTE: This toggle does not work quite as expected with --ascii flag
+      #       The --ascii flag should give the humanized output in non-interactive terminals
+      #       However the flag is not available at this point in the code execution
+      #
+      #       Fixing this will require an additional feature in OutputMode
       if $stdout.tty?
         Pathname.new(guide.path).relative_path_from Config::CACHE.howto_dir
       else
@@ -56,8 +63,18 @@ module FlightHowto
       end
     end
 
-    def self.pastel
-      @pastel ||= Pastel.new
+    # NOTE: OutputMode now considers 'true' to be explicitly on and 'false' as explicit off
+    #       The default handling is trigged by `nil` (e.g. verbose: nil)
+    #
+    #       However Slop can not pass a nil values for boolean flags,
+    #       so there needs to be an adaptation layer between the two.
+    def self.build_output(verbose: false, ascii: false, interactive: false)
+      opts = {}.tap do |o|
+        o[:verbose]     = true  if verbose
+        o[:ascii]       = true  if ascii
+        o[:interactive] = true  if interactive || ascii
+      end
+      super(header_color: :clear, row_color: :clear, **opts)
     end
   end
 end

--- a/lib/flight-howto/matcher.rb
+++ b/lib/flight-howto/matcher.rb
@@ -68,11 +68,6 @@ module FlightHowto
     end
 
     ##
-    # OBSOLETE: This method has reached EOL and is pending removal
-    def find_by_index(raw_index)
-      raise NotImplementedError
-    end
-
     # Filter the guides by name. Note the name must already be standardized
     def search_name(key)
       regex = /\A#{key}.*/
@@ -83,8 +78,10 @@ module FlightHowto
     end
 
     def search_content(key)
-      ids = picky.search(key).ids
-      ids.map { |id| id_map[id] }.sort_by(&:index)
+      picky.search(key)
+           .ids
+           .map { |id| id_map[id] }
+           .sort_by(&:index)
     end
 
     private

--- a/lib/flight-howto/matcher.rb
+++ b/lib/flight-howto/matcher.rb
@@ -27,6 +27,7 @@
 
 require_relative 'guide'
 require 'open3'
+require 'picky'
 
 module FlightHowto
   class Matcher
@@ -72,14 +73,38 @@ module FlightHowto
       raise NotImplementedError
     end
 
-    ##
-    # Filter the guides by a search key. Note: They key must already be standardized
-    def search(key)
+    # Filter the guides by name. Note the name must already be standardized
+    def search_name(key)
       regex = /\A#{key}.*/
       matching_guides = select do |guide|
         guide.parts.any? { |p| regex.match?(p)  }
       end
       self.class.new(matching_guides)
+    end
+
+    def search_content(key)
+      ids = picky.search(key).ids
+      ids.map { |id| id_map[id] }.sort_by(&:index)
+    end
+
+    private
+
+    def id_map
+      @id_map ||= guides.map { |g| [g.id, g] }.to_h
+    end
+
+    # Used to preform a search on the entire text body
+    def picky
+      @picky ||= begin
+        index = Picky::Index.new :guides do
+          indexing splits_text_on: /\s/
+          category :content, partial: Picky::Partial::None.new
+        end
+        guides.each { |g| index.add g }
+        Picky::Search.new index do
+          searching splits_text_on: /\s/
+        end
+      end
     end
   end
 end

--- a/lib/flight-howto/matcher.rb
+++ b/lib/flight-howto/matcher.rb
@@ -94,7 +94,7 @@ module FlightHowto
     def picky
       @picky ||= begin
         index = Picky::Index.new :guides do
-          indexing splits_text_on: /\s/
+          indexing splits_text_on: /\W/
           category :content, partial: Picky::Partial::None.new
         end
         guides.each { |g| index.add g }


### PR DESCRIPTION
Rebased to only contain search feature and `--ascii` flag

A new `search` command has been added which scans the howto guides for the search terms. This feature leverages the [picky library](http://florianhanke.com/picky/documentation.html#indexes-categories-partial) and preforms a key word search on the entire text body. Whilst the library does contain support for partial matches, these have been disabled for this pass. Each search term must be present in it's entirety.

Also the `--ascii` flag has been implemented.