### PR TITLE
Allow howto guides to be rendered

### DIFF
--- a/etc/config.reference
+++ b/etc/config.reference
@@ -54,6 +54,13 @@ config :howto_dir, default: File.join(flight_ROOT, 'usr/share/howto')
 config :minimum_terminal_width, default: 80, transform_with: ->(v) { v.to_i }
 
 # ==============================================================================
+# Template Config Directory
+# Specify the directory where templating configs are stored. The configs are
+# loaded in alphanumeric order
+# ==============================================================================
+config :template_config_dir, default: File.join(flight_ROOT, 'etc/howto.d')
+
+# ==============================================================================
 # Log Path
 # The file the logger will write to. It will write to standard error when set to
 # empty string.

--- a/lib/flight-howto/errors.rb
+++ b/lib/flight-howto/errors.rb
@@ -51,31 +51,33 @@ module FlightHowto
   GeneralError = Error.define_class(2)
   InputError = GeneralError.define_class(3)
 
-  InvalidFormatError = GeneralError.define_class(4) do
+  ConfigLoadError = GeneralError.define_class(4)
+
+  InvalidFormatError = GeneralError.define_class(5) do
     def initialize(content_filename)
       super("The file '#{content_filename}' appears to start with a metadata section (three or five dashes at the top) but it does not seem to be in the correct format.")
     end
   end
 
-  UnparseableMetadataError = GeneralError.define_class(5) do
+  UnparseableMetadataError = GeneralError.define_class(6) do
     def initialize(filename, error)
       super("Could not parse metadata for #{filename}: #{error.message}")
     end
   end
 
-  InvalidMetadataError = GeneralError.define_class(6) do
+  InvalidMetadataError = GeneralError.define_class(7) do
     def initialize(filename, klass)
       super("The file #{filename} has invalid metadata (expected key-value pairs, found #{klass} instead)")
     end
   end
 
-  InvalidEncodingError = GeneralError.define_class(8) do
+  InvalidEncodingError = GeneralError.define_class(9) do
     def initialize(filename, encoding)
       super("Could not read #{filename} because the file is not valid #{encoding}.")
     end
   end
 
-  FileUnreadableError = GeneralError.define_class(7) do
+  FileUnreadableError = GeneralError.define_class(10) do
     def initialize(filename, error)
       super("Could not read #{filename}: #{error.inspect}")
     end

--- a/lib/flight-howto/guide.rb
+++ b/lib/flight-howto/guide.rb
@@ -53,7 +53,8 @@ module FlightHowto
       super
 
       # Standardizes the case and word boundaries
-      name = self.class.standardize_string(File.basename(path, '.*'))
+      basename = File.basename(path).sub(/\..*\Z/, '')
+      name = self.class.standardize_string(basename)
 
       # Detects if an prefix has been provided
       match = PREFIX_REGEX.match(name)

--- a/lib/flight-howto/guide.rb
+++ b/lib/flight-howto/guide.rb
@@ -29,6 +29,7 @@ require 'tty-pager'
 
 require_relative 'markdown_renderer'
 require_relative 'parser'
+require_relative 'template_context'
 
 module FlightHowto
   PREFIX_REGEX  = /\A(?<prefix>\d+)_(?<rest>.*)\Z/
@@ -93,6 +94,10 @@ module FlightHowto
       ERROR
     end
 
+    def template?
+      /\.erb\Z/.match? path
+    end
+
     def parts
       @parts ||= joined.split('_')
     end
@@ -115,7 +120,10 @@ module FlightHowto
     end
 
     def content
-      parse_result.content
+      @content ||= begin
+        raw = parse_result.content
+        template? ? TemplateContext.load.render(raw) : raw
+      end
     end
 
     ##

--- a/lib/flight-howto/guide.rb
+++ b/lib/flight-howto/guide.rb
@@ -27,7 +27,7 @@
 
 require 'tty-pager'
 
-require_relative 'renderer'
+require_relative 'markdown_renderer'
 require_relative 'parser'
 
 module FlightHowto
@@ -122,7 +122,7 @@ module FlightHowto
     # Renders the markdown
     def render
       begin
-        Renderer.new(content).wrap_markdown
+        MarkdownRenderer.new(content).wrap_markdown
       rescue => e
         Config::CACHE.logger.error "Failed to pretty render: #{path}"
         Config::CACHE.logger.warn e.full_message

--- a/lib/flight-howto/markdown_renderer.rb
+++ b/lib/flight-howto/markdown_renderer.rb
@@ -29,7 +29,7 @@ require_relative '../patches/tty-markdown'
 require 'word_wrap'
 
 module FlightHowto
-  Renderer = Struct.new(:content, :width) do
+  MarkdownRenderer = Struct.new(:content, :width) do
     attr_reader :colors
 
     def initialize(*_)

--- a/lib/flight-howto/matcher.rb
+++ b/lib/flight-howto/matcher.rb
@@ -45,7 +45,7 @@ module FlightHowto
     ##
     # Helper method for loading in all the guides
     def self.load_guides
-      Dir.glob(File.join(Config::CACHE.howto_dir, '*\.md'))
+      Dir.glob(File.join(Config::CACHE.howto_dir, '*{\.md,\.md\.erb}'))
          .map { |p| Guide.new(p) }
          .tap do |guides|
         guides.reject!(&:admin?) unless admin?

--- a/lib/flight-howto/template_context.rb
+++ b/lib/flight-howto/template_context.rb
@@ -1,0 +1,77 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of FlightHowto.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightHowto is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightHowto. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightHowto, please visit:
+# https://github.com/openflighthpc/flight-howto
+#==============================================================================
+
+require 'erb'
+require 'ostruct'
+require 'pathname'
+require 'yaml'
+
+module FlightHowto
+  class TemplateContext < Hashie::Mash
+    def self.load
+      Pathname.new(Config::CACHE.template_config_dir)
+              .children(false)
+              .sort
+              .each_with_object(new) { |p, memo| memo.load_config(p) }
+    end
+
+    def load_config(pathname)
+      pathname = Pathname.new(pathname) unless pathname.is_a? Pathname
+
+      # Do not require the config to exist. Missing configs are considered as
+      # good as empty. This allows load_config to be embedded in templates easily
+      return unless pathname.exists?
+
+      # Error if the requested config does not give an absolute path, it should
+      # already be expanded
+      raise ConfigLoadError, <<~ERROR.chomp unless pathname.absolute?
+        Can not load the templating config as it is not an absolute path:
+        #{pathname.to_s}
+      ERROR
+
+      # Error if the config is not readable
+      raise ConfigLoadError, <<~ERROR.chomp unless pathname.readable?
+        Can not open the template config:
+        #{pathname.to_s}
+      ERROR
+
+      # Merge the config into the existing context
+      begin
+        merge!(**(YAML.load(pathname.read, symbolize_names: true) || {}))
+      rescue
+        raise ConfigLoadError, <<~ERROR.chomp
+          Failed to load the templating config! Please ensure it is valid YAML
+          #{pathname.to_s}
+        ERROR
+      end
+    end
+
+    def render(template)
+      ERB.new(template, nil, '-').result(self.binding)
+    end
+  end
+end

--- a/lib/flight-howto/template_context.rb
+++ b/lib/flight-howto/template_context.rb
@@ -75,7 +75,9 @@ module FlightHowto
     end
 
     def render(template)
-      ERB.new(template, nil, '-').result(self.binding)
+      Bundler.with_original_env do
+        ERB.new(template, nil, '-').result(self.binding)
+      end
     end
   end
 end

--- a/lib/flight-howto/template_context.rb
+++ b/lib/flight-howto/template_context.rb
@@ -76,7 +76,7 @@ module FlightHowto
 
     def render(template)
       Bundler.with_original_env do
-        ERB.new(template, nil, '-').result(to_module.__binding__)
+        ERB.new(template, nil, '-').result(to_module.to_binding)
       end
     end
 
@@ -91,9 +91,14 @@ module FlightHowto
           def const_missing(s)
             nil
           end
+
+          def to_binding
+            class_eval('binding')
+          end
         end
       end.tap do |mod|
         mod.instance_variable_set(:@context, self)
+
         mod.context.each do |key, value|
           # Skip keys which can not be constantized
           next unless /\A[[:alpha:]]\w*\Z/.match?(key.to_s)

--- a/lib/flight-howto/template_context.rb
+++ b/lib/flight-howto/template_context.rb
@@ -33,10 +33,14 @@ require 'yaml'
 module FlightHowto
   class TemplateContext < Hashie::Mash
     def self.load
-      Pathname.new(Config::CACHE.template_config_dir)
-              .children(false)
-              .sort
-              .each_with_object(new) { |p, memo| memo.load_config(p) }
+      if Dir.exists? Config::CACHE.template_config_dir
+        Pathname.new(Config::CACHE.template_config_dir)
+                .children(false)
+                .sort
+                .each_with_object(new) { |p, memo| memo.load_config(p) }
+      else
+        new
+      end
     end
 
     def load_config(pathname)


### PR DESCRIPTION
Howto guides can now be rendered using `ERB`. This is triggered by naming the template with the `.md.erb` file extension.

The templater is configurable by defining the a YAML config with `/opt/flight/etc/howto.d` directory. The default values will need to be placed within this directory as well. This is to decouple the defaults and their versioning from the underlining application.